### PR TITLE
インストールスクリプトのテスト

### DIFF
--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -1,0 +1,9 @@
+name: install-test
+run-name: test 
+on: [push]
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./setup.sh


### PR DESCRIPTION
- Github Actionsによるインストールスクリプトのテストを追加
- pushをトリガーとしてテストを実施する
- 環境はUbuntuのみテスト