### PR TITLE
Deinのpathを修正

### DIFF
--- a/neovim/init.vim
+++ b/neovim/init.vim
@@ -1,0 +1,75 @@
+set relativenumber
+
+" Ward off unexpected things that your distro might have made, as
+" well as sanely reset options when re-sourcing .vimrc
+set nocompatible
+set helplang=ja,en
+
+" Install Dein
+let $CACHE = expand('~/.cache')
+if !($CACHE->isdirectory())
+  call mkdir($CACHE, 'p')
+endif
+if &runtimepath !~# '/dein.vim'
+  let s:dir = 'dein.vim'->fnamemodify(':p')
+  if !(s:dir->isdirectory())
+    let s:dir = $CACHE .. '/dein/repos/github.com/Shougo/dein.vim'
+    if !(s:dir->isdirectory())
+      execute '!git clone https://github.com/Shougo/dein.vim' s:dir
+    endif
+  endif
+  execute 'set runtimepath^='
+        \ .. s:dir->fnamemodify(':p')->substitute('[/\\]$', '', '')
+endif
+
+" Set Dein base path (required)
+let s:dein_base = '~/.cache/dein'
+
+" Set Dein source path (required)
+let s:dein_src = '~/.cache/dein/repos/github.com/Shougo/dein.vim'
+
+" Set Dein runtime path (required)
+execute 'set runtimepath+=' . s:dein_src
+
+" Call Dein initialization (required)
+call dein#begin(s:dein_base)
+call dein#add('vim-airline/vim-airline')
+call dein#add('vim-airline/vim-airline-themes')
+call dein#add('tpope/vim-fugitive')
+call dein#add('vim-jp/vimdoc-ja')
+call dein#add('kassio/neoterm')
+call dein#add('tpope/vim-commentary')
+call dein#add('rafamadriz/neon')
+call dein#add(s:dein_src)
+
+" Your plugins go here:
+call dein#add('Shougo/neosnippet.vim')
+call dein#add('Shougo/neosnippet-snippets')
+
+" Finish Dein initialization (required)
+call dein#end()
+
+" Set colorscheme
+colorscheme neon
+
+" Set airline-theme
+let g:airline_theme='deus'
+let g:airline#extensions#tabline#enabled = 1
+
+" Attempt to determine the type of a file based on its name and possibly its
+" contents. Use this to allow intelligent auto-indenting for each filetype,
+" and for plugins that are filetype specific.
+if has('filetype')
+  filetype indent plugin on
+endif
+
+" Enable syntax highlighting
+if has('syntax')
+  syntax on
+endif
+
+" Uncomment if you want to install not-installed plugins on startup.
+if dein#check_install()
+ call dein#install()
+endif
+

--- a/setup.sh
+++ b/setup.sh
@@ -28,3 +28,16 @@ ln -sf $DOTFILE_HOME/git/.commit_messages ~/.commit_messages
 curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ln -sf $DOTFILE_HOME/vim/.vimrc ~/.vimrc
+
+# setup neovim
+curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim.appimage
+chmod u+x nvim.appimage
+./nvim.appimage --appimage-extract
+./squashfs-root/AppRun --version
+mkdir -p ~/.config/nvim
+ln -sf $DOTFILE_HOME/neovim/init.vim ~/.config/nvim/init.vim
+
+# Optional: exposing nvim globally.
+sudo mv squashfs-root /
+sudo ln -s /squashfs-root/AppRun /usr/bin/nvim
+


### PR DESCRIPTION
- Docker環境内でrootで開発していたため、pathが/root配下となっており、Deinにより正常にプラグインが読み込まれなかった。そのためpathをホームディレクトリ配下を参照するよう変更した。